### PR TITLE
Making fixed log scrollbars 17px wide to eliminate the gap..

### DIFF
--- a/app/styles/_log.less
+++ b/app/styles/_log.less
@@ -128,7 +128,7 @@
       background-color: @log-bg-color;
       bottom: 0;
       height: 30px;
-      right: @scrollbar-width;
+      right: @scrollbar-width-log-viewer;
       width: auto;
       &.dots div {
         left: 50%;
@@ -141,7 +141,7 @@
     }
     .log-scroll-bottom, .log-scroll-top {
       border-right-width: 1px;
-      right: 17px; // width of IE11 scrollbar
+      right: @scrollbar-width-log-viewer; // width of IE11 scrollbar
     }
     .log-view-output {
       overflow: auto;

--- a/app/styles/_scrollbars.less
+++ b/app/styles/_scrollbars.less
@@ -46,6 +46,11 @@
   }
 }
 
-.log-view.log-fixed-height  ::-webkit-scrollbar-track {
-  background-color: @scrollbar-track-inverse-alt;
+.log-view.log-fixed-height {
+  ::-webkit-scrollbar {
+    width: @scrollbar-width-log-viewer;
+  }
+  ::-webkit-scrollbar-track {
+    background-color: @scrollbar-track-inverse-alt;
+  }
 }

--- a/app/styles/_variables.less
+++ b/app/styles/_variables.less
@@ -95,6 +95,7 @@
 @scrollbar-track-inverse: @sidebar-os-border-color;
 @scrollbar-track-inverse-alt: rgba(255,255,255,.1);
 @scrollbar-width: 14px;
+@scrollbar-width-log-viewer: 17px;
 @status-bg-color: #E6ECF1;
 @status-border-color: #BFCEDB;
 @tileHeadingIconFontSize: 33px;


### PR DESCRIPTION
between the top/bottom links and the scrollbar itself.  Windows
scrollbars are 17px wide.  We should probably look at making all our
scrollbars 17px wide so we don’t have to override for this context.

@jwforres, PTAL.  FYI, @sg00dwin.

before:
<img width="125" alt="screen shot 2016-07-29 at 3 00 45 pm" src="https://cloud.githubusercontent.com/assets/895728/17260812/87875ac2-55a0-11e6-88a8-cbd6b304d334.PNG">

after:
<img width="116" alt="screen shot 2016-07-29 at 3 24 03 pm" src="https://cloud.githubusercontent.com/assets/895728/17260818/8f8298c2-55a0-11e6-9e0b-f3494ea5e1c7.PNG">

Microsoft Windows:
<img width="116" alt="screen shot 2016-07-29 at 3 02 51 pm" src="https://cloud.githubusercontent.com/assets/895728/17260830/9c699ad6-55a0-11e6-9d41-8be1a45ae2d7.PNG">
