### PR TITLE
Add rewrite rule for config.js

### DIFF
--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-if [ -f /openshift-web-console-config/config.js ]; then
-   cp -f /openshift-web-console-config/config.js config.js
-else
+if [ ! -f /openshift-web-console-config/config.js ]; then
    echo "No config.js is mounted, the console can not run without a configuration defined."
    exit -1
 fi

--- a/httpd-cfg/openshift-web-console.conf
+++ b/httpd-cfg/openshift-web-console.conf
@@ -5,9 +5,14 @@ Listen 0.0.0.0:8443
     SSLCertificateFile "${HTTPD_CONFIGURATION_PATH}/tls/tls.crt"
     SSLCertificateKeyFile "${HTTPD_CONFIGURATION_PATH}/tls/tls.key"
 
+    <Directory "/openshift-web-console-config">
+        Require all granted
+    </Directory>
+
     RewriteEngine on
     # First strip the context root
     RewriteRule ^${OSC_CONTEXT_ROOT}(.*) /$1
+    RewriteRule ^/config\.js$ /openshift-web-console-config/config.js [L]
     RewriteRule ^/java$ ${OSC_ASSET_PUBLIC_URL}java/ [R,L]
     RewriteCond %{DOCUMENT_ROOT}/java/$1 !-f
     RewriteRule ^/java/(.*)$ /java/index.html [L,PT]


### PR DESCRIPTION
Rewrite requests for config.js instead of copying the config.js on startup. This lets you edit config.js in the config map without redeploying.